### PR TITLE
Fix broken video link in Resource Library for Sowing techniques

### DIFF
--- a/index.html
+++ b/index.html
@@ -208,8 +208,9 @@
         <img src="images/25803500_1621011873.jpg" alt="PROJECT-IMG" border="0" />
         <div class="portfolio-layer">
           <h4>Sowing Techniques</h4>
-          <a href="https://www.youtube.com/watch?v=Z3HApiFKwb4&pp=ygUdc293aW5nIHRlY2huaXF1ZXMgYWdyaWN1bHR1cmU%3D" target="_blank"><i
+          <a href="https://youtu.be/xIe2EjQNols?si=3ZilfnJPM2t3jyYH"><i
               class='bx bx-link-external'></i></a>
+            <!-- Updated the video link -->
         </div>
       </div>
       <div class="portfolio-box">


### PR DESCRIPTION
Fixes Issue: #159 

Description:
The video link provided on the website for "Sowing techniques" under the Resource Library appears to be broken as the referenced video no longer exists. After investigating the issue, an alternative video covering the same topic has been identified.

Proposed Solution:
The proposed solution is to replace the broken video link with the alternative video provided, ensuring that users can access relevant content on the topic of sowing techniques.

Changes Made:

1. Replaced the broken video link with the alternative video link.
2. Conducted testing to verify that the new video link functions correctly.

Alternative Video Link:
[Alternative Video Link](https://youtu.be/xIe2EjQNols?si=OuS26K675xcZK1IK)

Checklist:
Before submitting my pull request, I have ensured that I have completed the following tasks:

I have followed the community guidelines outlined in the [Code of Conduct](https://github.com/Suchitra-Sahoo/AgriLearnNetwork/blob/main/CODE_OF_CONDUCT.md) for respectful and inclusive behavior.