### PR TITLE
Update footer copyright year to be dynamic

### DIFF
--- a/index.html
+++ b/index.html
@@ -315,7 +315,7 @@
 
       
       <div class="footer-text footer-right">
-        <p style="font-weight: 600; font-size: 20px;">Copyright &copy; 2024 by AgriLearnNetwork | All Rights Reserved.</p>
+        <p style="font-weight: 600; font-size: 20px;">Copyright &copy; <script>document.write(new Date().getFullYear())</script> by AgriLearnNetwork | All Rights Reserved.</p>
         </div>
     </footer>  
     


### PR DESCRIPTION
Fixed issue #179 

This pull request updates the footer copyright year to be dynamically generated using JavaScript. The current year is now displayed automatically, ensuring that the year is always up-to-date without manual intervention. This improves the user experience by reflecting the current year in the copyright notice.
