### PR TITLE
Close hamburger menu when navbar link is clicked

### DIFF
--- a/script.js
+++ b/script.js
@@ -2,11 +2,26 @@ let menuIcon = document.querySelectorAll('#menu-icon');
 let navbar = document.querySelectorAll('.navbar');
 let Contact = document.querySelectorAll('#contact');
 let navContact = document.querySelectorAll('#nav--contact');
+
 menuIcon.forEach(icon => {
   icon.onclick = () => {
     icon.classList.toggle('bx-x');
     navbar.forEach(nav => nav.classList.toggle('active'));
   }
+});
+
+// Add an event listener to navbar links
+document.querySelectorAll('.navbar a').forEach(link => {
+  link.addEventListener('click', () => {
+    // Remove 'active' class from navbar
+    document.querySelectorAll('.navbar').forEach(nav => {
+      nav.classList.remove('active');
+    });
+    // Toggle the menu icon
+    document.querySelectorAll('#menu-icon').forEach(icon => {
+      icon.classList.remove('bx-x'); // Remove the 'bx-x' class to close the hamburger menu
+    });
+  });
 });
 
 


### PR DESCRIPTION
1. This pull request modifies the JavaScript code to ensure that the hamburger menu is closed when a user clicks on any link inside the navbar. 

2. It adds an event listener to all navbar links, which removes the 'active' class from the navbar and closes the hamburger menu by removing the 'bx-x' class from the menu icon when a link is clicked. 

3. This enhances user experience by providing consistent behavior and ensuring that the menu does not remain open unnecessarily after a selection is made.