### PR TITLE
BUG: Footer "Quick Links" ul tag word gap is not good

### DIFF
--- a/style.css
+++ b/style.css
@@ -893,10 +893,10 @@ input[type="number"]::-webkit-inner-spin-button {
   cursor: pointer;
   transition: background-color 0.3s ease;
   position: absolute;
-  right: 0; /* Attach to the right edge */
-  top: 50%; /* Vertically center */
-  transform: translateY(-50%); /* Adjust for centering */
-  white-space: nowrap; /* Prevent text from wrapping */
+  right: 0; 
+  top: 50%; 
+  transform: translateY(-50%); 
+  white-space: nowrap; 
   
   
 
@@ -1437,9 +1437,9 @@ input[type="number"]::-webkit-inner-spin-button {
 .footer {
   padding: 20px;
   background-image: linear-gradient(rgba(0, 0, 0, 0.85), rgba(0, 0, 0, 0.85)), url('./images/istockphoto-1465642013-170667a.webp');
-  background-size: cover; /* Ensure the background image covers the entire container */
-  background-position: center; /* Center the background image */
-  background-repeat: no-repeat; /* Prevent the background image from repeating */
+  background-size: cover; 
+  background-position: center; 
+  background-repeat: no-repeat; 
   color: #fff;
 }
 
@@ -1538,10 +1538,12 @@ font-size: 36px;
 
 .quick-links ul {
   list-style-type: none;
-  padding: 0;
+  padding-left: 15%;
   display: flex;
+  flex-direction: row;
   align-items: center;
-  justify-content: space-between;
+  /* justify-content: space-between; */
+  gap: 3.5rem;
 }
 
 .quick-links li {
@@ -1556,13 +1558,13 @@ font-size: 36px;
 }
 
 .quick-links a:hover {
-  color: #f0f0f0; /* Change color on hover */
+  color: greenyellow; 
   text-decoration: underline;
 }
 
 @media (max-width: 768px) {
   .footer-grid {
-    grid-template-columns: 1fr; /* Single column layout for smaller screens */
+    grid-template-columns: 1fr; 
   }
   * Places these items above the icons in the single column layout */
   


### PR DESCRIPTION
#851
In this I added gap: 3rem and change the color of hover

#851 
In the footer section "Quick Links" <ul> tag I changed word gap to 3rem as well added hover effect with matching color effect.

#Request 
Please consider this PR, if you like this change on the footer section. Then please this PR and merge it under gssoc'24 and level this PR.

## Description
n the footer section "Quick Links" <ul> tag I changed word gap to 3rem as well added hover effect with matching color effect.


## Type of PR

- [ ] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

## Screenshots / videos (if applicable)
Before Change -

https://github.com/Suchitra-Sahoo/AgriLearnNetwork/assets/136844498/ff6cba21-0d46-4607-8ae2-234472f1962b

After Change -

https://github.com/Suchitra-Sahoo/AgriLearnNetwork/assets/136844498/7caefbbf-c9f9-434b-bc78-a684183c961b



## Checklist:
- [ ] I have performed a self-review of my code
- [ ] I have read and followed the Contribution Guidelines.
- [ ] I have tested the changes thoroughly before submitting this pull request.
- [ ] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [ ] I have commented my code, particularly in hard-to-understand areas.
<!-- [X] - put a cross/X inside [] to check the box -->

## Additional context:
[Include any additional information or context that might be helpful for reviewers.]
