### PR TITLE
Footer "Quick Links" tag hover effect improved

### DIFF
--- a/style.css
+++ b/style.css
@@ -1563,8 +1563,22 @@ font-size: 36px;
 }
 
 .quick-links a:hover {
-  color: #f0f0f0; /* Change color on hover */
-  text-decoration: underline;
+  color: #056a22; /* Change color on hover */
+  /* text-decoration: underline; */
+  animation: blink 1s step-start infinite;
+  text-shadow: 0 0 5px currentColor;
+}
+
+@keyframes blink {
+  50% {
+    text-shadow: 
+      0 0 10px rgba(255, 255, 255, 0.8), /* White glow */
+      0 0 20px rgba(255, 0, 0, 0.7),     /* Red glow */
+      0 0 30px rgba(255, 0, 255, 0.6);   /* Pink glow */
+  }
+  100% {
+    text-shadow: none;
+  }
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
#851
Here I improved the Footer "Quick Links" section where I added hover effect as well animation , text-shadow effects on the Footer "Quick Links" tag also I added keyFrames blink for animation.

#851 
BUG: Footer "Quick Links" ul tag word gap is not good

Video -

https://github.com/Suchitra-Sahoo/AgriLearnNetwork/assets/136844498/052da0f8-e8b2-4f46-bfd5-3fa320cc6999



## Type of PR

- [ ] Bug fix
- [x] Feature enhancement
- [x] Documentation update
- [ ] Other (specify): _______________

## Screenshots / videos (if applicable)
[Attach any relevant screenshots or videos demonstrating the changes]

## Checklist:
- [x] I have performed a self-review of my code
- [x] I have read and followed the Contribution Guidelines.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [x] I have commented my code, particularly in hard-to-understand areas.
<!-- [X] - put a cross/X inside [] to check the box -->

## Additional context:
[Include any additional information or context that might be helpful for reviewers.]
