### PR TITLE
Sets proper fonts size to FAQs

### DIFF
--- a/faqpage.html
+++ b/faqpage.html
@@ -83,14 +83,14 @@
               <h3>What features does AgriLearnNetwork offer?</h3>
             </div>
             <div class="accordion-body">
-              <p>AgriLearnNetwork offers a wide range of features, including:
-                1.Detailed farming guides
-                2.Crop and livestock management tips
-                3.Weather forecasting tools
-                4.Market price updates
-                5.Expert advice and consultancy services
-                6.Community forums for peer support
-                7.Access to research and best practices in agriculture
+              <p>AgriLearnNetwork offers a wide range of features, including:<br>
+                1.Detailed farming guides<br>
+                2.Crop and livestock management tips<br>
+                3.Weather forecasting tools<br>
+                4.Market price updates<br>
+                5.Expert advice and consultancy services<br>
+                6.Community forums for peer support<br>
+                7.Access to research and best practices in agriculture<br>
               </p>
             </div>
           </div>

--- a/faqpagestyle.css
+++ b/faqpagestyle.css
@@ -302,7 +302,8 @@ section {
 
 .faq .accordion-header h3 {
   width: 100%;
-  font-size: 1.2rem;
+  font-size: 1.8rem;
+  align-content: center;
   color: #000;
   margin: 0;
 }
@@ -311,7 +312,7 @@ section {
   display: none;
   padding: 1rem;
   line-height: 1.5;
-  font-size: 1.2rem;
+  font-size: 1.5rem;
   color: #000;
   background-color: #fff;
   transition: color 0.3s ease;
@@ -331,7 +332,7 @@ section {
 
 .faq .accordion-body:hover {
   color: rgb(26, 131, 66);
-  font-size:small ;
+  font-size:large ;
   font-weight:600 ;
 }
 


### PR DESCRIPTION
## Description
Hello @Suchitra-Sahoo (PA) I have fixed the issue #907 
Please review it and add appropriate labels to it

## Before :
Fonts size were too small and text is aligned to top 

![Screenshot 2024-06-24 150201](https://github.com/Suchitra-Sahoo/AgriLearnNetwork/assets/108344062/bb49acc3-0a7f-4e77-925a-fd1de65fe43d)


## After: 
Fonts size is updated with proper size and answer text is adjusted to center with break <br> tags

![Screenshot 2024-06-24 150227](https://github.com/Suchitra-Sahoo/AgriLearnNetwork/assets/108344062/81b701f5-209d-4faf-a722-12711b98ba47)
## Type of PR

- [ ] Bug fix
- [X] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

## Checklist:
- [X] I have performed a self-review of my code
- [X] I have read and followed the Contribution Guidelines.
- [X] I have tested the changes thoroughly before submitting this pull request.
- [X] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [X] I have commented my code, particularly in hard-to-understand areas.
<!-- [X] - put a cross/X inside [] to check the box -->
