### PR TITLE
Fix Terms/Privacy text responsive and Login Center

### DIFF
--- a/login/login.css
+++ b/login/login.css
@@ -81,6 +81,8 @@ body::before {
   width: 768px;
   max-width: 100%;
   min-height: 480px;
+  display: flex;
+  justify-content: center;
 }
 
 .container p {

--- a/testimonials/privacypolicy.html
+++ b/testimonials/privacypolicy.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Privacy Policy - AgriLearnNetwork</title>
    
-    <link rel="icon" href="icon.png" type="image/x-icon" />
+    <link rel="icon" href="../icon.png" type="image/x-icon" />
     <link rel="stylesheet" type="text/css" href="../style.css" />
   
     <link

--- a/testimonials/privacypolicy.html
+++ b/testimonials/privacypolicy.html
@@ -83,6 +83,20 @@
             color: #000;
         }
 
+        @media (max-width: 768px) {
+          .privacy-container .privacy-heading {
+                font-size: 20px;
+            }
+            .privacy-container .privacy-subheading
+            {
+              font-size: 16px;
+            }
+            .privacy-container .privacy-para
+            {
+              font-size: 14px;
+            }
+        }
+
     </style>
 <link rel="stylesheet" href="/Scrollbar/scrollbar.css">
 </head>

--- a/testimonials/termsandconditions.html
+++ b/testimonials/termsandconditions.html
@@ -84,7 +84,21 @@
             text-align: justify;
             color: black;
         }
-
+       
+      @media (max-width: 768px) {
+        .terms-container .terms-heading {
+              font-size: 20px;
+          }
+          .terms-container .terms-subheading
+          {
+            font-size: 16px;
+          }
+          .terms-container .terms-para
+          {
+            font-size: 14px;
+          }
+      }
+    
     </style>
     <link rel="stylesheet" href="/Scrollbar/scrollbar.css">
 


### PR DESCRIPTION
## Related Issue

Fixes : #1131

## Description

Terms and condition and privacy policy page text responsive for small screen.
Make Login page in center to avoid overlapping.
Added correct path for favicon in privacy policy page.

## Type of PR

- [x] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

## Screenshots / videos (if applicable)

![image](https://github.com/user-attachments/assets/37a96274-6562-412e-bbb6-4ad6319563fc)

![image](https://github.com/user-attachments/assets/9640f754-101c-4011-8ee3-8520b773e025)


![image](https://github.com/user-attachments/assets/b55634a8-5f9b-4dd9-8404-b4df611a050b)



## Checklist:
- [x] I have performed a self-review of my code
- [x] I have read and followed the Contribution Guidelines.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [x] I have commented my code, particularly in hard-to-understand areas.
<!-- [X] - put a cross/X inside [] to check the box -->

