### PR TITLE
Enhanced Separation in Quick Links Section

### DIFF
--- a/style.css
+++ b/style.css
@@ -1967,18 +1967,20 @@ font-size: 36px;
 }
 
 .quick-links {
- text-align: center;
- width: 50vw;
- padding: 20px;
- p{
-  font-weight: bold;
+  text-align: center;
+  width: 80vw;
+  padding: 20px;
 }
+
+.quick-links p {
+  font-weight: bold;
 }
 
 .quick-links h2 {
-  font-size: 20px;
+  font-size: 15px;
   margin-bottom: 15px;
 }
+
 
 .quick-links ul {
   list-style-type: none;
@@ -1986,10 +1988,23 @@ font-size: 36px;
   display: flex;
   align-items: center;
   justify-content: space-between;
+  margin: 0;
 }
 
 .quick-links li {
-  margin-bottom: 8px;
+  position: relative; /* To position the vertical line */
+  padding: 0 20px; /* Add horizontal padding to create space for the vertical line */
+}
+
+.quick-links li:not(:last-child)::after {
+  content: "|";
+  position: absolute;
+  right: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  color: #fff; 
+  font-size: 1.5rem; 
+  padding-left: 10px; 
 }
 
 .quick-links a {


### PR DESCRIPTION
## Related Issue
Feat: Separate Quick Links #1292
## Description
issue:
"The Quick Links section is not currently separated. Each link can be distinctly separated using vertical lines, similar to the method used in the Copyright and All Rights Reserved sections. This will enhance the clarity and visual separation of each link."

Changes made:
"Made changes under style.css file in Quick Link between each option provided a Vertical line to separate each option this enhances the readability and visibility of your project"

## Type of PR

- [ ] Bug fix
- [X] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

## Screenshots / videos (if applicable)
![Agri-updated-quick Link-ss](https://github.com/user-attachments/assets/f3ac4459-fa51-4dfc-ae2f-3df57d9955e7)


## Checklist:
- [X] I have performed a self-review of my code
- [X] I have read and followed the Contribution Guidelines.
- [X] I have tested the changes thoroughly before submitting this pull request.
- [X] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [X] I have commented my code, particularly in hard-to-understand areas.
<!-- [X] - put a cross/X inside [] to check the box -->

## Additional context:
[Include any additional information or context that might be helpful for reviewers.]
