### PR TITLE
Fixed overlap issue#1323 of the social media icon bar 

### DIFF
--- a/style.css
+++ b/style.css
@@ -2196,7 +2196,6 @@ font-size: 36px;
   position: fixed;
   top: 50%;
   transform: translateY(-50%);
-  z-index: 10;
 }
 
 .icon-bar a {


### PR DESCRIPTION
The social media icon which was originally overlapping with the testimonials arrow keys has been fixed.

Feature enhancement Video

https://github.com/user-attachments/assets/c68ad05e-0466-477e-a8c6-8ff56038b915



## Checklist:
- [X] I have performed a self-review of my code
- [X] I have read and followed the Contribution Guidelines.
- [X] I have tested the changes thoroughly before submitting this pull request.
- [X] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [X] I have commented my code, particularly in hard-to-understand areas.


